### PR TITLE
feat: change the price api from coingecko to defi llama

### DIFF
--- a/src/scripts/getTotalPricePerToken.ts
+++ b/src/scripts/getTotalPricePerToken.ts
@@ -1,28 +1,27 @@
 import axios from 'axios';
 import { BigNumber } from 'ethers';
 
+const getLlamaPrice = async (tokenAddress: string): Promise<number> => {
+  const res = await axios.get(`https://coins.llama.fi/prices/current/ethereum:${tokenAddress}`);
+  return res.data.coins[`ethereum:${tokenAddress}`].price;
+};
+
+const getCoingeckoPrice = async (tokenAddress: string): Promise<number> => {
+  const res = await axios.get(
+    `https://api.coingecko.com/api/v3/simple/token_price/ethereum?contract_addresses=${tokenAddress}&vs_currencies=usd`,
+  );
+  return res.data[tokenAddress].usd;
+};
+
 const getTotalPricePerToken = async (
   tokenAmount: BigNumber,
   tokenAddress: string,
 ): Promise<number> => {
-  try {
-    tokenAddress = tokenAddress.toLowerCase();
-    const res = await axios.get(`https://coins.llama.fi/prices/current/ethereum:${tokenAddress}`);
-    const result = tokenAmount.toNumber() * res.data.coins[`ethereum:${tokenAddress}`].price;
-    return result;
-  } catch (err) {
-    console.error(err);
-    try {
-      const res = await axios.get(
-        `https://api.coingecko.com/api/v3/simple/token_price/ethereum?contract_addresses=${tokenAddress}&vs_currencies=usd`,
-      );
-      const result = tokenAmount.toNumber() * res.data[tokenAddress].usd;
-      return result;
-    } catch (err2) {
-      console.error(err2);
-    }
-    return 0;
-  }
+  tokenAddress = tokenAddress.toLowerCase();
+  const tokenPrice = await getLlamaPrice(tokenAddress).catch(() =>
+    getCoingeckoPrice(tokenAddress).catch(() => 0),
+  );
+  return tokenPrice * tokenAmount.toNumber();
 };
 
 export default getTotalPricePerToken;

--- a/src/scripts/getTotalPricePerToken.ts
+++ b/src/scripts/getTotalPricePerToken.ts
@@ -12,6 +12,15 @@ const getTotalPricePerToken = async (
     return result;
   } catch (err) {
     console.error(err);
+    try {
+      const res = await axios.get(
+        `https://api.coingecko.com/api/v3/simple/token_price/ethereum?contract_addresses=${tokenAddress}&vs_currencies=usd`,
+      );
+      const result = tokenAmount.toNumber() * res.data[tokenAddress].usd;
+      return result;
+    } catch (err2) {
+      console.error(err2);
+    }
     return 0;
   }
 };

--- a/src/scripts/getTotalPricePerToken.ts
+++ b/src/scripts/getTotalPricePerToken.ts
@@ -7,10 +7,8 @@ const getTotalPricePerToken = async (
 ): Promise<number> => {
   try {
     tokenAddress = tokenAddress.toLowerCase();
-    const res = await axios.get(
-      `https://api.coingecko.com/api/v3/simple/token_price/ethereum?contract_addresses=${tokenAddress}&vs_currencies=usd`,
-    );
-    const result = tokenAmount.toNumber() * res.data[tokenAddress].usd;
+    const res = await axios.get(`https://coins.llama.fi/prices/current/ethereum:${tokenAddress}`);
+    const result = tokenAmount.toNumber() * res.data.coins[`ethereum:${tokenAddress}`].price;
     return result;
   } catch (err) {
     console.error(err);


### PR DESCRIPTION
Change the price api used from coingecko to defi llama to get more accurate data + it will not be affected if coingecko is down. Also added coingecko as callback